### PR TITLE
Remove ERC20feeProxy from constructor and remove comp claim rewards test

### DIFF
--- a/contracts/Paytr.sol
+++ b/contracts/Paytr.sol
@@ -63,11 +63,10 @@ contract Paytr is Ownable, Pausable, ReentrancyGuard {
         address feeAddress;
     } 
  
-    constructor(address _cometAddress, address _wrapperAddress, address _ERC20FeeProxyAddress, uint16 _feeModifier, uint8 _minDueDateInDays, uint16 _maxDueDateInDays, uint256 _minAmount, uint256 _maxAmount, uint8 _maxPayoutArraySize) {
+    constructor(address _cometAddress, address _wrapperAddress, uint16 _feeModifier, uint8 _minDueDateInDays, uint16 _maxDueDateInDays, uint256 _minAmount, uint256 _maxAmount, uint8 _maxPayoutArraySize) {
         cometAddress = _cometAddress;
         baseAsset = IComet(cometAddress).baseToken();
         wrapperAddress = _wrapperAddress;
-        ERC20FeeProxyAddress = _ERC20FeeProxyAddress;
         feeModifier = _feeModifier;
         minDueDateInDays = _minDueDateInDays;
         maxDueDateInDays = _maxDueDateInDays;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
 const Paytr = artifacts.require("Paytr.sol");
 
 module.exports = function (deployer) {
-  deployer.deploy(Paytr, "0xc3d688B66703497DAA19211EEdff47f25384cdc3","0xFd55fCd10d7De6C6205dBBa45C4aA67d547AD8F2","0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE",10, 7, 30, 10, 100000000000, 5);//100,000 USDC
+  deployer.deploy(Paytr, "0xc3d688B66703497DAA19211EEdff47f25384cdc3", "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE", 10, 7, 30, 10, 100000000000, 5);//100,000 USDC
 };

--- a/test/paytr_test_payment_big_amount_and_compRewards.js
+++ b/test/paytr_test_payment_big_amount_and_compRewards.js
@@ -114,13 +114,6 @@ contract("Paytr", (accounts) => {
       assert(contractUSDCBalanceAfterBalanceTransfer < contractUSDCBalanceAfterPayOut, "contract USDC balance doesn't match");
       assert(contractUSDCBalanceAfterBalanceTransfer == 0, "contract USDC balance should be 0");
 
-      let ownerCompBalanceBeforeClaiming = await compTokenContract.methods.balanceOf(accounts[0]).call();
-      console.log("Owner $COMP balance before claiming $COMP rewards: ", ownerCompBalanceBeforeClaiming);
-      await instance.claimCompRewards();
-      let ownerCompBalanceAfterClaiming = await compTokenContract.methods.balanceOf(accounts[0]).call();
-      console.log("Owner $COMP balance before claiming $COMP rewards: ", ownerCompBalanceAfterClaiming);
-
-
 
   })//end describe
 


### PR DESCRIPTION
The Request Network contracts are not deployed on all chains. Removing the ERC20FeeProxy address will improve the contract's initial deployment flow.
The ERC20FeeProxy address can be set later on by calling the `setERC20FeeProxy` function.

Remove the claim $COMP rewards test, there is no $COMP accrual in the current test for now.