### PR TITLE
Fix _totalInterestGathered calculation, gas savings on payout loop

### DIFF
--- a/test/helpers/parameters.js
+++ b/test/helpers/parameters.js
@@ -4,7 +4,7 @@ const CometContract = new web3.eth.Contract(CometAbi, "0xF09F0369aB0a875254fB565
 const wrapperContract = new web3.eth.Contract(wrapperContractABI, "0x797D7126C35E0894Ba76043dA874095db4776035");
 const USDCContract = new web3.eth.Contract(Erc20Abi, "0xDB3cB4f2688daAB3BFf59C24cC42D4B6285828e9");
 const cTokenContract = new web3.eth.Contract(Erc20Abi, "0xF09F0369aB0a875254fB565E52226c88f10Bc839");
-const whaleAccount = "0xFC078A6812eb56320f879A153A0bd23C34D9B508";
+const whaleAccount = "0x9a06153141114AAd45bf28F35521a40c4952C6FF";
 const compTokenContract = new web3.eth.Contract(Erc20Abi, "0xc00e94Cb662C3520282E6f5717214004A7f26888");
 const provider = config.provider;
 

--- a/test/paytr_test.js
+++ b/test/paytr_test.js
@@ -20,7 +20,6 @@ contract("Paytr", (accounts) => {
     //check supply rate
     let supplyRate = await CometContract.methods.getSupplyRate(cometSupplyRateParam).call();
     assert(supplyRate > 0);
-    console.log(whaleAccount);
 
     await USDCContract.methods.approve(instance.address, 1000000000000).send({from: whaleAccount});
     let wTokenBalanceBeforeTx = await wrapperContract.methods.balanceOf(instance.address).call();

--- a/test/paytr_test_multiple_invoices_all_due.js
+++ b/test/paytr_test_multiple_invoices_all_due.js
@@ -79,7 +79,7 @@ contract("Paytr", (accounts) => {
       let whaleAccountBalanceAfterTx2 = await USDCContract.methods.balanceOf(whaleAccount).call();
 
       assert.equal(cUSDCTokenBalanceBeforeTx2,cUSDCTokenBalanceAfterTx2,"cUSDC token balance should match because it get's (un)wrapped");
-      assert.equal(whaleAccountBalanceAfterTx2,expectedWhaleAccountBalanceAfterTx2,"Whale account balance doens't match expected balance after tx2");
+      assert.equal(whaleAccountBalanceAfterTx2,expectedWhaleAccountBalanceAfterTx2,"Whale account balance doensn't match expected balance after tx2");
       assert(wTokenBalanceAfterTx2 > wTokenBalanceBeforeTx2, "wToken balance hasn't changed");
 
       //increase time and block number to force interest gathering. Without both, Truffle test throws an arithmetic overflow error
@@ -108,7 +108,7 @@ contract("Paytr", (accounts) => {
       let expectedPayeeUSDCBalanceAfterPayout = (web3.utils.toBN(payeeUSDCBalanceInitial).add(web3.utils.toBN(amountToPayInv1)).add(web3.utils.toBN(amountToPayInv2))).toString();
       
       assert(cUSDCTokenBalanceAfterRedeemingFromCompound == 0, "cUSDC token balance should be 0");
-      assert(USDCTokenBalanceBeforeRedeemingFromCompound < USDCTokenBalanceAfterRedeemingFromCompound, "Contract's Contract's USDC balance doesn't match");
+      assert(USDCTokenBalanceBeforeRedeemingFromCompound < USDCTokenBalanceAfterRedeemingFromCompound, "Contract's USDC balance doesn't match");
       assert(wTokenBalanceAfterRedeemingFromCompound <= 1, "Contract wToken balance > 1");
       assert(whaleAccountBalanceAfterInterestPayout > whaleAccountBalanceAfterTx2,"Wrong whale balance after interest payout");
       assert.equal(expectedPayeeUSDCBalanceAfterPayout, payeeUSDCBalance,"Payee USDC balance mismatch");

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -8,8 +8,7 @@ module.exports = {
     development: {
       host: "127.0.0.1",
       port: 8545,
-      network_id: "*", // match any network
-      gasPrice: 14
+      network_id: "*" // match any network
     },  
   },
   dashboard: {


### PR DESCRIPTION
The _totalInterestGathered calculation contained a bug.
The formed calculation was:
`uint256 _totalInterestGathered = IERC20(baseAsset).balanceOf(address(this)) - _amount - _feeAmount;`

This is only correct when the contract's baseAsset balance before redeeming is 0.
Example:
The baseAsset before redeeming is 1000, the _amount to be redeemed is 10 and the _feeAmount is 0.
This would mean the contract's balance is sent to the payer. The _totalInterestGathered would be:
1010.0003 - 10 - 0 (using .0003 interest in this example).
The payer would receive 1000.0003 interest on an initial payment of 10, which is incorrect.

The calculation is now correct by querying the contract's balance before and after the redeeming, and using these values in the new calculation:
`_totalInterestGathered = baseAssetBalanceAfterCometWithdraw - baseAssetBalanceBeforeCometWithdraw - _amount - _feeAmount;`

Removed the payable keyword, moved more variables to the top of the function in order to use them in memory -> saving more gas.